### PR TITLE
CI test for IGNITE-28822 (do not merge)

### DIFF
--- a/modules/calcite/src/main/java/org/apache/ignite/internal/processors/query/calcite/message/QueryStartResponse.java
+++ b/modules/calcite/src/main/java/org/apache/ignite/internal/processors/query/calcite/message/QueryStartResponse.java
@@ -24,7 +24,7 @@ import org.apache.ignite.plugin.extensions.communication.Message;
 import org.jetbrains.annotations.Nullable;
 
 /**
- *
+ * CI test for IGNITE-28822: protected class change, expected to be flagged.
  */
 public class QueryStartResponse implements Message {
     /** */

--- a/modules/codegen/src/main/java/org/apache/ignite/internal/Order.java
+++ b/modules/codegen/src/main/java/org/apache/ignite/internal/Order.java
@@ -23,6 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * CI test for IGNITE-28822: annotation definition file, must NOT be flagged (content has no Order import).
  * The annotation specifies the position of a field in the serialized and deserialized byte sequence of a {@code Message} class.
  * <p>
  * The {@code value} indicates the index of the field in the serialization order.


### PR DESCRIPTION
Tests the new Protected Classes detection script (base branch `ignite-28822` carries it; `pull_request_target` runs the workflow from base).

Changes:
- **QueryStartResponse.java** — protected class (`@Order`) → **expected: flagged** (comment + `compatibility` label + `action_required` check).
- **codegen/Order.java** — the `@Order` annotation *definition* file → **expected: NOT flagged** (old diff-based grep matched the path in diff headers; new content-based grep does not).

Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)