### PR TITLE
CI test for IGNITE-28822 — green case (do not merge)

### DIFF
--- a/modules/codegen/src/main/java/org/apache/ignite/internal/Order.java
+++ b/modules/codegen/src/main/java/org/apache/ignite/internal/Order.java
@@ -23,6 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * CI test for IGNITE-28822: only the @Order definition file changes, expected NOT flagged (check must stay green).
  * The annotation specifies the position of a field in the serialized and deserialized byte sequence of a {@code Message} class.
  * <p>
  * The {@code value} indicates the index of the field in the serialization order.


### PR DESCRIPTION
Touches **only** `codegen/Order.java` (the `@Order` annotation definition file).

Expected: **affected=false → check GREEN**, no comment, no label.
The old diff-based grep matched the file path in diff headers → false positive (would be red). The new content-based grep does not. Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)