### PR TITLE
DEMO IGNITE-28821: protected-class change shows warning, not failure

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/util/distributed/TestIntegerMessage.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/util/distributed/TestIntegerMessage.java
@@ -20,7 +20,7 @@ package org.apache.ignite.internal.util.distributed;
 import org.apache.ignite.internal.Order;
 import org.apache.ignite.plugin.extensions.communication.Message;
 
-/** */
+/** Test message carrying a single integer payload. */
 public class TestIntegerMessage implements Message {
     /** */
     @Order(0)


### PR DESCRIPTION
## Purpose
Demonstration-only PR for [IGNITE-28821](https://issues.apache.org/jira/browse/IGNITE-28821).

It targets the `ignite-28821` branch (which contains the reworked `Protected Classes` workflow), so the `pull_request_target` event runs the **new** workflow definition.

The single commit makes a trivial Javadoc change to `TestIntegerMessage`, an `@Order`-annotated (protected) class. This is exactly the kind of change that previously failed the PR build.

## Expected behavior with the new workflow
- `Rolling Upgrade check` job → **succeeds** (no more `exit 1`).
- A separate non-blocking check `Rolling upgrade compatibility` is published with the `action_required` conclusion (yellow marker).
- The explanatory PR comment is posted and the `compatibility` label is added.

Not intended to be merged.